### PR TITLE
Set stricter elixir version range

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LagerLogger.Mixfile do
   def project do
     [app: :lager_logger,
      version: "0.9.0",
-     elixir: "~> 1.0",
+     elixir: ">= 1.0.0 and <= 1.0.3",
      package: package,
      description: description,
      deps: deps]


### PR DESCRIPTION
LagerLogger abuses Logger internals (`Logger.Config.__data__/0`) so only include elixir versions known to work. 

When used as a dependency a warning will appear for Elixir `1.1.0-dev` (and so 1.1.0) so may not want to merge.
