### PR TITLE
Update dependencies to compile on latest Elixir release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ elixir:
   - 1.5
   - 1.6
 otp_release:
-  - 18.2.1
-  - 19
-  - 20
+  - 19.0
+  - 20.0
 matrix:
   exclude:
     - elixir: 1.2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: elixir
 elixir:
-  - 1.1.1
-  - 1.2.6
-  - 1.3.1
+  - 1.5
+  - 1.6
 otp_release:
-  - 17.5
   - 18.2.1
+  - 19
+  - 20
 matrix:
   exclude:
     - elixir: 1.2.6

--- a/lib/lager_logger.ex
+++ b/lib/lager_logger.ex
@@ -32,9 +32,9 @@ defmodule LagerLogger do
   """
   @spec flush() :: :ok
   def flush() do
-    _ = GenEvent.which_handlers(:error_logger)
-    _ = GenEvent.which_handlers(:lager_event)
-    _ = GenEvent.which_handlers(Logger)
+    _ = :gen_event.which_handlers(:error_logger) # From Elixir upstream Logger module.
+    _ = :gen_event.which_handlers(:lager_event) # Legacy? From this codebase.
+    :gen_event.sync_notify(Logger, :flush) # From Elixir upstream Logger module.
     :ok
   end
 
@@ -115,8 +115,8 @@ defmodule LagerLogger do
   end
 
   # Stolen from Logger.
-  defp notify(:sync, msg),  do: GenEvent.sync_notify(Logger, msg)
-  defp notify(:async, msg), do: GenEvent.notify(Logger, msg)
+  defp notify(:sync, msg), do: :gen_event.sync_notify(Logger, msg)
+  defp notify(:async, msg), do: :gen_event.notify(Logger, msg)
 
   @doc false
   # Lager's parse transform converts the pid into a charlist. Logger's metadata expects pids as

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LagerLogger.Mixfile do
   def project do
     [app: :lager_logger,
      version: "1.0.4",
-     elixir: ">= 1.1.0 and < 1.5.0",
+     elixir: "~> 1.5",
      package: package(),
      description: description(),
      deps: deps()]


### PR DESCRIPTION
This PR fixes deprecation warnings when compiling, such as `GenEvent`, which is now called via the Erlang module `:gen_event` instead. It [the PR] bases itself on Elixir upstream's Logger module. 

The PR also updates the version of Elixir supported to `~> 1.5`, but this may not be the best choice. Feel free to cherry pick the PR.

I've tested the PR on my own Elixir application, and it appears to run fine, but feel free to test the PR more extensively.