### PR TITLE
Allow/support to use lager_logger with elixir 1.8.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LagerLogger.Mixfile do
   def project do
     [app: :lager_logger,
      version: "1.0.5",
-     elixir: ">= 1.1.0 and < 1.7.0",
+     elixir: ">= 1.1.0 and < 1.9.0",
      package: package(),
      description: description(),
      deps: deps()]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule LagerLogger.Mixfile do
 
   def project do
     [app: :lager_logger,
-     version: "1.0.5",
+     version: "1.0.6",
      elixir: ">= 1.1.0 and < 1.9.0",
      package: package(),
      description: description(),


### PR DESCRIPTION
Made the change. Was running `mix test`. It passed.

Is there a reason why lager_logger is not allowing/supporting elixir 1.8.1.

If not, can we please merge this?