### PR TITLE
Extend support to Elixir 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,21 @@ matrix:
       otp_release: 17.5
     - elixir: 1.3.1
       otp_release: 17.5
+  include:
+    - elixir: 1.4.5
+      otp_release: 20.3
+    - elixir: 1.5.3
+      otp_release: 20.3
+    - elixir: 1.6.6
+      otp_release: 20.3
+    - elixir: 1.7.4
+      otp_release: 22.2
+    - elixir: 1.8.2
+      otp_release: 22.2
+    - elixir: 1.9.4
+      otp_release: 22.2
+    - elixir: 1.10.2
+      opt_release: 22.2
 sudo: false # to use faster container based build environment
 script:
   - mix test

--- a/lib/lager_logger.ex
+++ b/lib/lager_logger.ex
@@ -32,7 +32,10 @@ defmodule LagerLogger do
   """
   @spec flush() :: :ok
   def flush() do
-    _ = :gen_event.which_handlers(:error_logger)
+    if Process.whereis(:error_logger) do
+      _ = :gen_event.which_handlers(:error_logger)
+    end
+
     _ = :gen_event.which_handlers(:lager_event)
     _ = :gen_event.which_handlers(Logger)
     :ok

--- a/lib/lager_logger.ex
+++ b/lib/lager_logger.ex
@@ -32,9 +32,9 @@ defmodule LagerLogger do
   """
   @spec flush() :: :ok
   def flush() do
-    _ = GenEvent.which_handlers(:error_logger)
-    _ = GenEvent.which_handlers(:lager_event)
-    _ = GenEvent.which_handlers(Logger)
+    _ = :gen_event.which_handlers(:error_logger)
+    _ = :gen_event.which_handlers(:lager_event)
+    _ = :gen_event.which_handlers(Logger)
     :ok
   end
 
@@ -119,8 +119,8 @@ defmodule LagerLogger do
   end
 
   # Stolen from Logger.
-  defp notify(:sync, msg),  do: GenEvent.sync_notify(Logger, msg)
-  defp notify(:async, msg), do: GenEvent.notify(Logger, msg)
+  defp notify(:sync, msg),  do: :gen_event.sync_notify(Logger, msg)
+  defp notify(:async, msg), do: :gen_event.notify(Logger, msg)
 
   @doc false
   # Lager's parse transform converts the pid into a charlist. Logger's metadata expects pids as

--- a/lib/lager_logger.ex
+++ b/lib/lager_logger.ex
@@ -49,37 +49,70 @@ defmodule LagerLogger do
     end
   end
 
-  @doc false
-  def handle_event({:log, lager_msg}, mask) do
-    %{mode: mode, truncate: truncate, level: min_level, utc_log: utc_log?} = Logger.Config.__data__
-    level = severity_to_level(:lager_msg.severity(lager_msg))
+  cond do
+    Version.compare(System.version(), "1.10.0") == :lt ->
+      @doc false
+      def handle_event({:log, lager_msg}, mask) do
+        level = severity_to_level(:lager_msg.severity(lager_msg))
 
-    if :lager_util.is_loggable(lager_msg, mask, __MODULE__) and
-      Logger.compare_levels(level, min_level) != :lt do
+        case mode(level) do
+          :discard ->
+            :ok
 
-      metadata = :lager_msg.metadata(lager_msg) |> normalize_pid
+          mode ->
+            min_level = Logger.level()
 
-      # lager_msg's message is already formatted chardata
-      message = Logger.Utils.truncate(:lager_msg.message(lager_msg), truncate)
+            if :lager_util.is_loggable(lager_msg, mask, __MODULE__) and
+               Logger.compare_levels(level, min_level) != :lt do
 
-      # Lager always uses local time and converts it when formatting using :lager_util.maybe_utc
-      timestamp = timestamp(:lager_msg.timestamp(lager_msg), utc_log?)
+              metadata = :lager_msg.metadata(lager_msg) |> normalize_pid
 
-      group_leader = case Keyword.fetch(metadata, :pid) do
-        {:ok, pid} when is_pid(pid) ->
-          case Process.info(pid, :group_leader) do
-            {:group_leader, gl} -> gl
-            nil -> Process.group_leader # if pid dead, pretend it's us as must be a pid
-          end
-        _ -> Process.group_leader # if lager didn't give us a pid just pretend it's us
+              # lager_msg's message is already formatted chardata
+              truncate = truncate(level)
+              message = Logger.Utils.truncate(:lager_msg.message(lager_msg), truncate)
+
+              # Lager always uses local time and converts it when formatting using :lager_util.maybe_utc
+              timestamp = timestamp(:lager_msg.timestamp(lager_msg), utc_log?())
+
+              group_leader = case Keyword.fetch(metadata, :pid) do
+                {:ok, pid} when is_pid(pid) ->
+                  case Process.info(pid, :group_leader) do
+                    {:group_leader, gl} -> gl
+                    nil -> Process.group_leader # if pid dead, pretend it's us as must be a pid
+                  end
+                _ -> Process.group_leader # if lager didn't give us a pid just pretend it's us
+              end
+
+              _ = notify(mode, {level, group_leader, {Logger, message, timestamp, metadata}})
+            end
+        end
+
+        {:ok, mask}
       end
 
-      _ = notify(mode, {level, group_leader, {Logger, message, timestamp, metadata}})
-      {:ok, mask}
-    else
-      {:ok, mask}
-    end
+      # Stolen from Logger.
+      defp notify(:sync, msg),  do: :gen_event.sync_notify(Logger, msg)
+      defp notify(:async, msg), do: :gen_event.notify(Logger, msg)
+    true ->
+      @doc false
+      def handle_event({:log, lager_msg}, mask) do
+        level = severity_to_level(:lager_msg.severity(lager_msg))
+        min_level = Logger.level()
+
+        if :lager_util.is_loggable(lager_msg, mask, __MODULE__) and
+           Logger.compare_levels(level, min_level) != :lt do
+          metadata = :lager_msg.metadata(lager_msg) |> normalize_pid
+
+          # lager_msg's message is already formatted chardata
+          message = :lager_msg.message(lager_msg)
+
+          Logger.bare_log(level, message, metadata)
+        end
+
+        {:ok, mask}
+      end
   end
+
 
   @doc false
   def handle_call(:get_loglevel, mask) do
@@ -118,9 +151,46 @@ defmodule LagerLogger do
     end
   end
 
-  # Stolen from Logger.
-  defp notify(:sync, msg),  do: :gen_event.sync_notify(Logger, msg)
-  defp notify(:async, msg), do: :gen_event.notify(Logger, msg)
+  cond do
+   Version.compare(System.version(), "1.9.0") == :lt ->
+     defp mode(_level) do
+       mode =
+         Logger.Config.__data__()
+         |> Map.fetch!(:mode)
+
+       mode
+     end
+
+     defp truncate(_level) do
+       Logger.Config.__data__()
+       |> Map.fetch!(:truncate)
+     end
+
+     defp utc_log? do
+       Logger.Config.__data__()
+       |> Map.fetch!(:utc_log)
+     end
+   Version.compare(System.version(), "1.10.0") == :lt ->
+     defp mode(level) do
+       # https://github.com/elixir-lang/elixir/blob/762989b39f62e8dc8153f5ea6c71c57693ffc3f3/lib/logger/lib/logger.ex#L671-L674
+       case Logger.Config.log_data(level) do
+         {:discard, _config} -> :discard
+         {mode, _config} -> mode
+       end
+     end
+
+     defp truncate(level) do
+       {_, %{truncate: truncate}} = Logger.Config.log_data(level)
+
+       truncate
+     end
+
+     defp utc_log? do
+       Application.fetch_env!(:logger, :utc_log)
+     end
+   true ->
+     :ok
+  end
 
   @doc false
   # Lager's parse transform converts the pid into a charlist. Logger's metadata expects pids as

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule LagerLogger.Mixfile do
 
   def project do
     [app: :lager_logger,
-     version: "1.0.5",
-     elixir: ">= 1.9.0 and < 1.10.0",
+     version: "1.1.0",
+     elixir: ">= 1.1.0 and < 1.11.0",
      package: package(),
      description: description(),
      deps: deps()]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LagerLogger.Mixfile do
   def project do
     [app: :lager_logger,
      version: "1.0.5",
-     elixir: ">= 1.1.0 and < 1.7.0",
+     elixir: ">= 1.9.0 and < 1.10.0",
      package: package(),
      description: description(),
      deps: deps()]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "goldrush": {:hex, :goldrush, "0.1.6", "8e224150c6994cc908bfee63c55e60262edbc0c60ee618b0b90bc3167a0d50c7", [:make, :rebar], []},
-  "lager": {:hex, :lager, "2.1.1", "8e389f916384abf5f62169969bd7515c4c252cbbda53feebbef90f47db5eaad1", [:make, :rebar], [{:goldrush, "~> 0.1.6", [hex: :goldrush, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], [], "hexpm", "15e3a816bdc53d12f258ea59d0c1fae9a37da2e70a0cb486edad687f65a36f66"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "5c30e436a5acfdc2fd8fe6866585fcaf30f434c611d8119d4f3390ced2a550f3"},
+  "goldrush": {:hex, :goldrush, "0.1.6", "8e224150c6994cc908bfee63c55e60262edbc0c60ee618b0b90bc3167a0d50c7", [:make, :rebar], [], "hexpm", "46a83aecf4bebc6355b6f73030fbb2e3fd240180302808fbdacfd8ab9c578f1a"},
+  "lager": {:hex, :lager, "2.1.1", "8e389f916384abf5f62169969bd7515c4c252cbbda53feebbef90f47db5eaad1", [:make, :rebar], [{:goldrush, "~> 0.1.6", [hex: :goldrush, repo: "hexpm", optional: false]}], "hexpm", "5eb1c17ff0f8692285b7648ef5d827d492b8d7554da782afc300ebb4861d5aba"},
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Support Elixir `< 1.10.0` instead of <` 1.7.0`.

## Bug Fixes
* Don't use deprecated `GenEvent`.
* Protect from `error_logger` not being started as is the case for newer OTP.